### PR TITLE
smartctl-disks-discovery.pl: get list of block devices with lsblk

### DIFF
--- a/discovery-scripts/linux/smartctl-disks-discovery.pl
+++ b/discovery-scripts/linux/smartctl-disks-discovery.pl
@@ -7,7 +7,7 @@ $first = 1;
 print "{\n";
 print "\t\"data\":[\n\n";
 
-for (`/bin/lsblk -d -n -o NAME`)
+for (`/bin/lsblk -d -n -o NAME -e 1,11,43,147`)
 {
 #DISK LOOP
 $smart_avail=0;

--- a/discovery-scripts/linux/smartctl-disks-discovery.pl
+++ b/discovery-scripts/linux/smartctl-disks-discovery.pl
@@ -7,21 +7,15 @@ $first = 1;
 print "{\n";
 print "\t\"data\":[\n\n";
 
-for (`ls -l /dev/disk/by-id/ | cut -d"/" -f3 | sort -n | uniq -w 3`)
+for (`/bin/lsblk -d -n -o NAME`)
 {
 #DISK LOOP
 $smart_avail=0;
 $smart_enabled=0;
 $smart_enable_tried=0;
 
-#next when total 0 at output
-        if ($_ eq "total 0\n")
-                {
-                        next;
-                }
-
-    print "\t,\n" if not $first;
-    $first = 0;
+print "\t,\n" if not $first;
+$first = 0;
 
 $disk =$_;
 chomp($disk);


### PR DESCRIPTION
It seems to me using lsblk is simpler and it's output doesn't include virtual devices like md0.