### PR TITLE
Added megaraid devices support. Changed script folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,21 +5,21 @@ This is the template for Zabbix providing SMART monitoring for HDD using smartct
 #Installation:
 ##Linux/BSD/Mac OSX:
 - Make sure that smartmontools utils are installed:
-- install the script smartctl-disks-discovery.pl in /usr/local/bin/
+- install the script smartctl-disks-discovery.pl in /etc/zabbix/scripts/
 - test the script by running it. You should receive JSON object in the script output
 - add the following permissions into /etc/sudoers:
 ```
-zabbix ALL= (ALL) NOPASSWD: /usr/sbin/smartctl,/usr/local/bin/smartctl-disks-discovery.pl
+zabbix ALL= (ALL) NOPASSWD: /usr/sbin/smartctl,/etc/zabbix/scripts/smartctl-disks-discovery.pl
 ```
 Add the following lines in zabbix_agentd.conf file:
 ```
 #############SMARTMON
-UserParameter=uHDD[*], sudo smartctl -A /dev/$1| grep "$2"| tail -1| cut -c 88-|cut -f1 -d' '
-UserParameter=uHDD.model.[*],sudo smartctl -i /dev/$1 |grep "Device Model"| cut -f2 -d: |tr -d " "
-UserParameter=uHDD.sn.[*],sudo smartctl -i /dev/$1 |grep "Serial Number"| cut -f2 -d: |tr -d " "
-UserParameter=uHDD.health.[*],sudo smartctl -H /dev/$1 |grep "test"| cut -f2 -d: |tr -d " "
-UserParameter=uHDD.errorlog.[*],sudo smartctl -l error /dev/$1 |grep "ATA Error Count"| cut -f2 -d: |tr -d " "
-UserParameter=uHDD.discovery,sudo /usr/local/bin/smartctl-disks-discovery.pl
+UserParameter=uHDD[*], sudo smartctl -A $1| grep -i "$2"| tail -1| cut -c 88-|cut -f1 -d' '
+UserParameter=uHDD.model.[*],sudo smartctl -i $1 |grep -i "Device Model"| cut -f2 -d: |tr -d " "
+UserParameter=uHDD.sn.[*],sudo smartctl -i $1 |grep -i "Serial Number"| cut -f2 -d: |tr -d " "
+UserParameter=uHDD.health.[*],sudo smartctl -H $1 |grep -i "test"| cut -f2 -d: |tr -d " "
+UserParameter=uHDD.errorlog.[*],sudo smartctl -l error $1 |grep -i "ATA Error Count"| cut -f2 -d: |tr -d " "
+UserParameter=uHDD.discovery,sudo /etc/zabbix/scripts/smartctl-disks-discovery.pl
 ```
 ###Building deb package
 You can create .deb package `zabbix-agent-extra-smartctl` for Debian/Ubuntu distributions:

--- a/discovery-scripts/nix/smartctl-disks-discovery.pl
+++ b/discovery-scripts/nix/smartctl-disks-discovery.pl
@@ -14,13 +14,9 @@ if ($^O eq 'darwin') { # if MAC OSX
         }
 }
 else {
-        for (`$smartctl_cmd --scan`) {
+        for (`$smartctl_cmd --scan-open`) {
             #splitting lines like "/dev/sda -d scsi # /dev/sda, SCSI device"
             my @device = split / /, $_;
-            #replacing -d scsi by -d sat for geting SMART at sata devices
-            if (@device[2] =~ /scsi/) {
-                @device[2] = sat;
-            }
             #Adding full value from smartctl --scan to get SMART from not only /dev/sd devices but /dev/bus/0 -d megaraid,01 too
             $disk = "@device[0] @device[1] @device[2]";
                 push @disks,$disk;

--- a/sudoers_zabbix_smartctl
+++ b/sudoers_zabbix_smartctl
@@ -1,1 +1,1 @@
-zabbix ALL=(ALL) NOPASSWD: /usr/sbin/smartctl,/usr/lib/zabbix/scripts/smartctl-disks-discovery.pl
+zabbix ALL=(ALL) NOPASSWD: /usr/sbin/smartctl,/etc/zabbix/scripts/smartctl-disks-discovery.pl

--- a/zabbix_smartctl.conf
+++ b/zabbix_smartctl.conf
@@ -1,7 +1,7 @@
 #############SMARTMON
-UserParameter=uHDD[*], sudo smartctl -A /dev/$1| grep "$2"| tail -1| cut -c 88-|cut -f1 -d' '
-UserParameter=uHDD.model.[*],sudo smartctl -i /dev/$1 |grep "Device Model"| cut -f2 -d: |tr -d " "
-UserParameter=uHDD.sn.[*],sudo smartctl -i /dev/$1 |grep "Serial Number"| cut -f2 -d: |tr -d " "
-UserParameter=uHDD.health.[*],sudo smartctl -H /dev/$1 |grep "test"| cut -f2 -d: |tr -d " "
-UserParameter=uHDD.errorlog.[*],sudo smartctl -l error /dev/$1 |grep "ATA Error Count"| cut -f2 -d: |tr -d " "
-UserParameter=uHDD.discovery,sudo /usr/lib/zabbix/scripts/smartctl-disks-discovery.pl
+UserParameter=uHDD[*], sudo smartctl -A $1| grep -i "$2"| tail -1| cut -c 88-|cut -f1 -d' '
+UserParameter=uHDD.model.[*],sudo smartctl -i $1 |grep -i "Device Model"| cut -f2 -d: |tr -d " "
+UserParameter=uHDD.sn.[*],sudo smartctl -i $1 |grep -i "Serial Number"| cut -f2 -d: |tr -d " "
+UserParameter=uHDD.health.[*],sudo smartctl -H $1 |grep -i "test"| cut -f2 -d: |tr -d " "
+UserParameter=uHDD.errorlog.[*],sudo smartctl -l error $1 |grep -i "ATA Error Count"| cut -f2 -d: |tr -d " "
+UserParameter=uHDD.discovery,sudo /etc/zabbix/scripts/smartctl-disks-discovery.pl


### PR DESCRIPTION
All test were made for smartmontools release 6.4
Added megaraid devices support 
Added workaround for /dev/sd devices by replacing -d scsi to -d sat to get SMART health status and attributes. IMHO it is some smartmontools bug. 
Created ticket https://www.smartmontools.org/ticket/811
Other files changed accordingly to new script path