### PR TITLE
adjust regex to match attribute on Crucial SSD

### DIFF
--- a/Template_3.4_HDD_SMARTMONTOOLS_2_WITH_LLD.xml
+++ b/Template_3.4_HDD_SMARTMONTOOLS_2_WITH_LLD.xml
@@ -337,7 +337,7 @@ https://en.wikipedia.org/wiki/S.M.A.R.T.#Known_ATA_S.M.A.R.T._attributes</descri
                             <preprocessing>
                                 <step>
                                     <type>5</type>
-                                    <params>5 Reallocated.+ ([0-9]+)
+                                    <params>5 Reallocate.+ ([0-9]+)
 \1</params>
                                 </step>
                             </preprocessing>


### PR DESCRIPTION
With Crucial/Micron it is called "Reallocate_NAND_Blk_Cnt".
Adjusting pattern so it can match this as well.