### PR TITLE
Areca SATA RAID Controller support + optimizations

### DIFF
--- a/discovery-scripts/nix/smartctl-disks-discovery.pl
+++ b/discovery-scripts/nix/smartctl-disks-discovery.pl
@@ -171,23 +171,6 @@ sub get_smart_disks {
                 $disk->{disk_type} = 0;
             }
         }
-        if ( !exists($disk->{disk_type})) {
-
-                $disk->{disk_type} = 2;
-                foreach my $extended_line (`$smartctl_cmd -a $disk->{disk_cmd} 2>&1`){
-
-                    #search for Spin_Up_Time or Spin_Retry_Count
-                    if ($extended_line  =~ /Spin_/){
-                        $disk->{disk_type} = 0;
-                        last;
-                    }
-                    #search for SSD in uppercase
-                    elsif ($extended_line  =~ / SSD /){
-                        $disk->{disk_type} = 1;
-                        last;
-                    }
-                }
-        }
 
         if ( $line =~ /Permission denied/ ) {
 
@@ -215,6 +198,24 @@ sub get_smart_disks {
 
         }
         
+    }
+
+    if ( !exists($disk->{disk_type})) {
+
+            $disk->{disk_type} = 2;
+            foreach my $extended_line (`$smartctl_cmd -a $disk->{disk_cmd} 2>&1`){
+
+                #search for Spin_Up_Time or Spin_Retry_Count
+                if ($extended_line  =~ /Spin_/){
+                    $disk->{disk_type} = 0;
+                    last;
+                }
+                #search for SSD in uppercase
+                elsif ($extended_line  =~ / SSD /){
+                    $disk->{disk_type} = 1;
+                    last;
+                }
+            }
     }
 
     if ( $disk->{subdisk} == 0 and $vendor eq "Areca" and $product eq "RAID controller" ) {

--- a/discovery-scripts/nix/smartctl-disks-discovery.pl
+++ b/discovery-scripts/nix/smartctl-disks-discovery.pl
@@ -133,6 +133,8 @@ sub get_smart_disks {
         }
     }
     
+    my $vendor = '';
+    my $product = '';
     foreach my $line (@smartctl_output) {
         
         if ( $line =~ /^serial number: +(.+)$/i ) {
@@ -152,6 +154,12 @@ sub get_smart_disks {
         }
         elsif ( $line =~ /^Device Model: +(.+)$/ ) {
                 $disk->{disk_model} = $1;
+        }
+        elsif ( $line =~ /^Vendor: +(.+)$/ ) {
+                $vendor = $1;
+        }
+        elsif ( $line =~ /^Product: +(.+)$/ ) {
+                $product = $1;
         }
         
         if ( $line =~ /Rotation Rate: (.+)/ ) {
@@ -208,6 +216,22 @@ sub get_smart_disks {
         }
         
     }
+
+    if ( $disk->{subdisk} == 0 and $vendor eq "Areca" and $product eq "RAID controller" ) {
+        for (my $i = 1; $i <= 16; $i++) {
+            push @disks,
+                get_smart_disks(
+                    {
+                        disk_name => $disk->{disk_name},
+                        disk_args => "-d areca,$i",
+                        disk_model => '',
+                        disk_sn => '',
+                        subdisk   => 1
+                    }
+                );
+        }
+    }
+  
     push @disks, $disk;
     return @disks;
 

--- a/discovery-scripts/nix/smartctl-disks-discovery.pl
+++ b/discovery-scripts/nix/smartctl-disks-discovery.pl
@@ -238,6 +238,7 @@ sub get_smart_disks {
                     }
                 );
         }
+        return @disks;
     }
   
     push @disks, $disk;

--- a/discovery-scripts/nix/smartctl-disks-discovery.pl
+++ b/discovery-scripts/nix/smartctl-disks-discovery.pl
@@ -132,6 +132,13 @@ sub get_smart_disks {
             }
         }
     }
+
+    foreach my $line (@smartctl_output) {
+        # Areca: filter out empty slots
+        if ( $line =~ /^Read Device Identity failed: empty IDENTIFY data/ ) {
+            return;
+        }
+    }
     
     my $vendor = '';
     my $product = '';

--- a/discovery-scripts/nix/smartctl-disks-discovery.pl
+++ b/discovery-scripts/nix/smartctl-disks-discovery.pl
@@ -103,6 +103,9 @@ sub get_smart_disks {
     $disk->{disk_cmd} = $disk->{disk_name};
     if (length($disk->{disk_args}) > 0){
         $disk->{disk_cmd}.=q{ }.$disk->{disk_args};
+        if ( $disk->{subdisk} == 1 and $disk->{disk_args} =~ /-d\s+[^,\s]+,(\S+)/) {
+            $disk->{disk_name} .= " ($1)";
+        }
     }
 
     #my $testline = "open failed: Two devices connected, try '-d usbjmicron,[01]'";


### PR DESCRIPTION
Hello.
I've added Areca SATA RAID Controller support.
Please note that SAS RAID Controllers are not supported: different syntax is needed (slot/enclosure number instead of just slot number) and they support much more disks (up to 512) making simple brute-force search not possible (1024 slot/enclosure combinations).
I also had to make some optimizations, which effectively reduced scan time from 18 to 5 seconds in my case. I removed excessive smartctl calls, filtered out non-disk devices (enclosures, dvd drives etc.).