### PR TITLE
Updated regex for disk model in the template 3.4

### DIFF
--- a/Template_3.4_HDD_SMARTMONTOOLS_2_WITH_LLD.xml
+++ b/Template_3.4_HDD_SMARTMONTOOLS_2_WITH_LLD.xml
@@ -236,7 +236,7 @@
                             <preprocessing>
                                 <step>
                                     <type>5</type>
-                                    <params>[Dd]evice [Mm]odel: +(.+)
+                                    <params>(?:[Dd]evice [Mm]odel|[Mm]odel [Nn]umber): +(.+)
 \1</params>
                                 </step>
                             </preprocessing>


### PR DESCRIPTION
changed regex to (?:[Dd]evice [Mm]odel|[Mm]odel [Nn]umber): +(.+)

fixes #76 