### PR TITLE
fix disks detection - remove duplicate SN

### DIFF
--- a/discovery-scripts/windows/smartctl-disks-discovery.ps1
+++ b/discovery-scripts/windows/smartctl-disks-discovery.ps1
@@ -128,20 +128,6 @@ foreach ($smart_scanresult in $smart_scanresults)
         }
     }
 
-    if ($sn) {
-        $disk_sn=$sn.trim()
-    
-        if ($global_serials -contains $disk_sn ){
-            continue
-            #skip duplicated disk, go to next one
-        } else {
-            #add only smart capable disks to global serials
-            if ($smart_enabled -eq 1){
-                $global_serials+=$disk_sn
-            }
-        }
-    }
-              
     if ($idx -eq 1)
     {
         


### PR DESCRIPTION
Hi. In windows discovery i detect that not all disks seen in discovery: 

wrong
![image](https://user-images.githubusercontent.com/42067951/59022115-da71ce80-8855-11e9-8432-4060edd5e769.png)
right:
![image](https://user-images.githubusercontent.com/42067951/59022177-ec537180-8855-11e9-9375-f2c6aa7ee9da.png)

And zabbix showed me, than "Value should be a JSON object" in LLD

After fix, that's all right