### PR TITLE
SMART status detection for ST4000.+ SAS disk

### DIFF
--- a/discovery-scripts/nix/smartctl-disks-discovery.pl
+++ b/discovery-scripts/nix/smartctl-disks-discovery.pl
@@ -165,7 +165,7 @@ sub get_smart_disks {
     foreach my $line (@smartctl_output) {
         #foreach my $line ($testline) {
         #print $line;
-        if ( $line =~ /^SMART.+?: +(.+)$/ ) {
+        if ( $line =~ /^(?:SMART.+?: +|Device supports SMART and is +)(.+)$/ ) {
 
             if ( $1 =~ /Enabled/ ) {
                 $disk->{smart_enabled} = 1;


### PR DESCRIPTION
fixes #101 

```
smartctl -i -H -A -l error -l background -d megaraid,3  /dev/sdb
smartctl 5.43 2016-09-28 r4347 [x86_64-linux-2.6.32-754.14.2.el6.x86_64] (local build)
Copyright (C) 2002-12 by Bruce Allen, http://smartmontools.sourceforge.net

Vendor:               SEAGATE 
Product:              ST4000NM0023    
Revision:             0006
User Capacity:        4.000.787.030.016 bytes [4,00 TB]
Logical block size:   512 bytes
Logical Unit id:      0x5000c5008584b023
Serial number:        Z1ZB1QCV0000R642XXXX
Device type:          disk
Transport protocol:   SAS
Local Time is:        Sat Jun 15 20:39:27 2019 EEST
Device supports SMART and is Enabled
Temperature Warning Enabled
SMART Health Status: OK
```