### PR TITLE
Ansible: Validate sudoers before copying

### DIFF
--- a/ansible/ansible-agent-install.yml
+++ b/ansible/ansible-agent-install.yml
@@ -13,6 +13,8 @@
     copy:
       src: ../sudoers_zabbix_smartctl
       dest: /etc/sudoers.d/sudoers_zabbix_smartctl
+      validate: "visudo -cf %s"
+      mode: 0440
   - name: "Copy agent config"
     copy:
       src: ../zabbix_smartctl.conf


### PR DESCRIPTION
To ensure that you do not break your sudoers configuration the file is validated as a safety precaution.

(I managed to brick my server since i forgot a line break when copying sudoers_zabbix_smartctl to my ansible scripts)
Source: https://docs.ansible.com/ansible/latest/modules/copy_module.html