### PR TITLE
Fixing issue #98 regexp of SMART health

### DIFF
--- a/Template_3.4_HDD_SMARTMONTOOLS_2_WITH_LLD.xml
+++ b/Template_3.4_HDD_SMARTMONTOOLS_2_WITH_LLD.xml
@@ -1048,7 +1048,7 @@ Setting this macro doesn't prevent any automatic attempts to discover disks usin
                             <preprocessing>
                                 <step>
                                     <type>5</type>
-                                    <params>(?:SMART overall-health self-assessment test result:|SMART Health Status:) +(.+)
+                                    <params>(?:SMART overall-health self-assessment test result:|SMART Health Status:) +\b([\S ]+)
 \1</params>
                                 </step>
                             </preprocessing>

--- a/Template_3.4_HDD_SMARTMONTOOLS_2_WITH_LLD.xml
+++ b/Template_3.4_HDD_SMARTMONTOOLS_2_WITH_LLD.xml
@@ -160,7 +160,7 @@ Setting this macro doesn't prevent any automatic attempts to discover disks usin
                             <preprocessing>
                                 <step>
                                     <type>5</type>
-                                    <params>(?:SMART overall-health self-assessment test result:|SMART Health Status:) +(.+)
+                                    <params>(?:SMART overall-health self-assessment test result:|SMART Health Status:) +\b([\S ]+)
 \1</params>
                                 </step>
                             </preprocessing>


### PR DESCRIPTION
Issue shows in trigger SMART status with windows agents only as far as I know. Change was advised by @v-zhuravlev , fixes the issue for windows agent, and linux agents are still working.