### PR TITLE
Fixed sudoers file permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ zabbix ALL= (ALL) NOPASSWD: SMARTCTL, SMARTCTL_DISCOVERY
 Defaults!SMARTCTL !logfile, !syslog, !pam_session
 Defaults!SMARTCTL_DISCOVERY !logfile, !syslog, !pam_session
 ```
+```text
+chmod 440 /etc/sudoers.d/sudoers_zabbix_smartctl
+```
 
 - Copy `zabbix_smartctl.conf` to `/etc/zabbix/zabbix_agentd.d`
 - Copy script `smartctl-disks-discovery.pl` to `/etc/zabbix/scripts`


### PR DESCRIPTION
Ubuntu 18.04:
```
root@srv:~# visudo -c
/etc/sudoers: parsed OK
/etc/sudoers.d/README: parsed OK
/etc/sudoers.d/sudoers_zabbix_smartctl: bad permissions, should be mode 0440
```