### PR TITLE
[FIXED] Wrong path variable for create_ansible_role.sh

### DIFF
--- a/create_ansible_role.sh
+++ b/create_ansible_role.sh
@@ -3,4 +3,4 @@ ANSIBLE_ROLE_DIR=./ansible-role-zabbix-smartmontools
 
 cp ./discovery-scripts/nix/smartctl-disks-discovery.pl $ANSIBLE_ROLE_DIR/files/
 cp ./sudoers_zabbix_smartctl $ANSIBLE_ROLE_DIR/files/
-cp ./zabbix_smartctl.conf $ANSIBLE_ROLE_DIR/Rfiles/
+cp ./zabbix_smartctl.conf $ANSIBLE_ROLE_DIR/files/

--- a/create_ansible_role.sh
+++ b/create_ansible_role.sh
@@ -3,4 +3,4 @@ ANSIBLE_ROLE_DIR=./ansible-role-zabbix-smartmontools
 
 cp ./discovery-scripts/nix/smartctl-disks-discovery.pl $ANSIBLE_ROLE_DIR/files/
 cp ./sudoers_zabbix_smartctl $ANSIBLE_ROLE_DIR/files/
-cp ./zabbix_smartctl.conf $ANSIBLE_ROLE_DI/Rfiles/
+cp ./zabbix_smartctl.conf $ANSIBLE_ROLE_DIR/Rfiles/


### PR DESCRIPTION
Wrong path of `R` for variable `ANSIBLE_ROLE_DIR` in the script `create_ansible_role.sh`

``` bash
cp ./zabbix_smartctl.conf $ANSIBLE_ROLE_DI/Rfiles/
```