### PR TITLE
Update create_ansible_role.sh

### DIFF
--- a/create_ansible_role.sh
+++ b/create_ansible_role.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 ANSIBLE_ROLE_DIR=./ansible-role-zabbix-smartmontools
 
+mkdir -p ./ansible-role-zabbix-smartmontools/files
 cp ./discovery-scripts/nix/smartctl-disks-discovery.pl $ANSIBLE_ROLE_DIR/files/
 cp ./sudoers_zabbix_smartctl $ANSIBLE_ROLE_DIR/files/
 cp ./zabbix_smartctl.conf $ANSIBLE_ROLE_DIR/files/


### PR DESCRIPTION
script create_ansible_role.sh fails because ./ansible-role-zabbix-smartmontools/**files** directory does not exist before the copy commands try to put files into it.  I simply added a mkdir -p to create the directory.