### PR TITLE
Add cciss discovery

### DIFF
--- a/discovery-scripts/nix/smartctl-disks-discovery.pl
+++ b/discovery-scripts/nix/smartctl-disks-discovery.pl
@@ -10,6 +10,7 @@ my $smartctl_cmd = "/usr/sbin/smartctl";
 die "Unable to find smartctl. Check that smartmontools package is installed.\n" unless (-x $smartctl_cmd);
 my $sg_scan_cmd = "/usr/bin/sg_scan";
 my $nvme_cmd = "/usr/sbin/nvme";
+my $cciss_dev_dir = "/dev/cciss";
 my @input_disks;
 my @global_serials;
 my @smart_disks;
@@ -98,6 +99,24 @@ else {
             }
 
         }
+    }
+
+    if (-d $cciss_dev_dir){
+        #cciss_vol_status /dev/cciss/c0d0 -V should be used for listing of drives, but currently I have no servers
+        #with more than 1 drive with this contoller
+        
+	    opendir(DIR, $cciss_dev_dir);
+	    while (my $file = readdir(DIR)) {
+		next unless ($file =~ m/^c\d+d\d+$/);
+		my ($disk_name) = $cciss_dev_dir."/".$file;
+		my ($disk_args) = "-d cciss,0";
+
+		push @input_disks,
+		{
+			disk_name => $disk_name,
+			disk_args => $disk_args
+		};
+	    }
     }
 
     if (-x $nvme_cmd){


### PR DESCRIPTION
I added 'quick and dirty' support for discovering disks on servers with raid controller that uses cciss linux driver. Exact model of my controller is 'HP Smart Array E200i'. On these servers I have no /dev/sd* , nor /dev/sg* devices. All disk devices are in /dev/cciss directory and look like: 
```
ls /dev/cciss 
c0d0  c0d0p1  c0d0p2  c0d0p5  c0d0p6
```

According to man smartctl, smart information should be got using `smartctl -d cciss,N` from them where N is disk number. But unfortunately I have no servers with more than one disk with such raid contoller that's why I was able to hardcode only one disk.

My suggestion is that the best way to discover all disk is parsing output of `cciss_vol_status /dev/cciss/c0d0 -V` (`apt-get install cciss-vol-status` in debian) but I can update the code only if I have output of it with more than 1 disk in the system.

